### PR TITLE
Change HSM v1 API references to v2

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,16 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-07-01
+
+### Changed
+
+- Replaced hsm v1 to hsm v2.
+
+### Added
+
+- Added TPM State BIOS interface
+
 ## [2.1.2] - 2022-06-23
 
 ### Changed

--- a/charts/v2.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v2.1/cray-hms-scsd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-scsd"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-scsd"
 home: "https://github.com/Cray-HPE/hms-scsd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.13.0"
+appVersion: "1.15.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-scsd/values.yaml
+++ b/charts/v2.1/cray-hms-scsd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.13.0
-  testVersion: 1.13.0
+  appVersion: 1.15.0
+  testVersion: 1.15.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-scsd
@@ -51,7 +51,7 @@ cray-service:
           containerPort: 25309
       env:
         - name: SCSD_SMD_URL
-          value: "http://cray-smd/hsm/v1"
+          value: "http://cray-smd/hsm/v2"
         - name: SCSD_HTTP_LISTEN_PORT
           value: "25309"
         - name: SCSD_LOCAL_MODE

--- a/cray-hms-scsd.compatibility.yaml
+++ b/cray-hms-scsd.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.11.0"
   "2.1.1": "1.11.0"
   "2.1.2": "1.13.0"
+  "2.1.3": "1.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Change HSM v1 API references to v2

## Issues and Related PRs

* Resolves [CASMHMS-5551](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5551)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable