### PR TITLE
Added TPM BIOS support for cray servers

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.5] - 2022-11-16
+
+### Changed
+
+- Added BIOS support for TPM for cray servers
+
 ## [2.1.4] - 2022-07-20
 
 ### Changed

--- a/charts/v2.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v2.1/cray-hms-scsd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-scsd"
-version: 2.1.4
+version: 2.1.5
 description: "Kubernetes resources for cray-hms-scsd"
 home: "https://github.com/Cray-HPE/hms-scsd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.16.0"
+appVersion: "1.17.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-scsd/values.yaml
+++ b/charts/v2.1/cray-hms-scsd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.16.0
-  testVersion: 1.16.0
+  appVersion: 1.17.0
+  testVersion: 1.17.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-scsd

--- a/cray-hms-scsd.compatibility.yaml
+++ b/cray-hms-scsd.compatibility.yaml
@@ -18,6 +18,7 @@ chartVersionToApplicationVersion:
   "2.1.2": "1.13.0"
   "2.1.3": "1.15.0"
   "2.1.4": "1.16.0"
+  "2.1.5": "1.17.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for enabling and disabling TPM for cray servers
## Issues and Related PRs

* Resolves CASMHMS-5596
* Merge after https://github.com/Cray-HPE/hms-scsd/pull/53

## Testing

Tested on:

  * odin with castle severs

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable