### PR TITLE
CASMHMS-6418: Updated image and module dependencies for security updates

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - 2025-03-21
+## [3.1.0] - 2025-03-25
 
 ### Security
 

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -1,0 +1,17 @@
+# Changelog for v3.1
+
+All notable changes to this project for v3.1.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.1.0] - 2025-03-21
+
+### Security
+
+- Updated image and module dependencies for security updates
+- Various code changes to accomodate module updates
+- Updated Go vo v1.24
+- Resolved build warnings in Dockerfiles and docker compose files
+- Stopped using legacy Bocker builder
+- Internal tracking ticket: CASMHMS-6418

--- a/charts/v3.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v3.1/cray-hms-scsd/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: "cray-hms-scsd"
+version: 3.1.0
+description: "Kubernetes resources for cray-hms-scsd"
+home: "https://github.com/Cray-HPE/hms-scsd-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-scsd"
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.21.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-scsd/templates/configmap.yaml
+++ b/charts/v3.1/cray-hms-scsd/templates/configmap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scsd-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"

--- a/charts/v3.1/cray-hms-scsd/templates/tests/test-smoke.yaml
+++ b/charts/v3.1/cray-hms-scsd/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-scsd"]

--- a/charts/v3.1/cray-hms-scsd/values.yaml
+++ b/charts/v3.1/cray-hms-scsd/values.yaml
@@ -1,0 +1,100 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 1.21.0
+  testVersion: 1.21.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-scsd
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-scsd-test
+    pullPolicy: IfNotPresent
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-scsd"
+  fullnameOverride: "cray-scsd"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-scsd
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-scsd:
+      name: "cray-scsd"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-scsd"
+      ports:
+        - name: http
+          containerPort: 25309
+      env:
+        - name: SCSD_SMD_URL
+          value: "http://cray-smd/hsm/v2"
+        - name: SCSD_HTTP_LISTEN_PORT
+          value: "25309"
+        - name: SCSD_LOCAL_MODE
+          value: "true"
+        - name: VAULT_KEYPATH
+          value: "secret/hms-creds"
+        - name: VAULT_ENABLED
+          value: "true"
+        - name: SCSD_KAFKA_URL
+          value: "cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092"
+        - name: SCSD_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: scsd-cacert-info
+              key: CA_URI
+        # Remove this to have hmnfd use ETCD.  The etcd operator will
+        # provide the hmnfd container with ETCD_HOST and ETCD_PORT to
+        # allow it to determine the KV URL.
+        # - name: KV_URL
+        #   value: "mem:"
+      livenessProbe:
+        httpGet:
+          port: 25309
+          path: /v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 25309
+          path: /v1/readiness
+        initialDelaySeconds: 5
+        periodSeconds: 30
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/scsd

--- a/cray-hms-scsd.compatibility.yaml
+++ b/cray-hms-scsd.compatibility.yaml
@@ -4,12 +4,14 @@ chartVersionToCSMVersion:
   # Summary:
   #   Chart Version: 2.0.0 <= x.y.z < 2.1.0, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   #   Chart Version: 2.1.0 <= x.y.z < 3.0.0, CSM Version: 1.3.0 <= x.y.z < 1.6.0
-  #   Chart Version: 3.0.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #   Chart Version: 3.0.0 <= x.y.z < 3.1.0  CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 3.1.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0"
   ">=2.1.0": "~1.3.0"
   ">=3.0.0": "~1.6.0"
+  ">=3.1.0": "~1.7.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -29,6 +31,7 @@ chartVersionToApplicationVersion:
   "3.0.0": "1.19.0"
   "3.0.1": "1.19.0"
   "3.0.2": "1.20.0"
+  "3.1.0": "1.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Fixed pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Latest images/modules require building with the `musl` tag.

Fixed a bunch of calls to ```Errorf(emsg)``` which are now required to be ```Errorf("%s", emsg)``` with Go v1.24 and later.

Updating the hms-base module required changes to reference code that was moved from hms-base to the hms-xname module.

Fixed bug in runSnyk.sh that prevented jq from parsing success.

We were building our unit tests with the legacy builder which is now deprecated so switched to BuildKit.

The github.com/Cray-HPE/hms-trs-app-api module was NOT updated as part of this effort.  It currently sits at v1.6.2 and would be a substantial effort to upgrade it to the latest v3.0.4.  [CASMHMS-6446](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6446) was opened to track this added effort so that we can quickly get the other security updates completed.

Adopted app version 1.21.0 for CSM 1.7.0 (helm chart 3.1.0)

### Issues and Related PRs

* Resolves [CASMHMS-6418](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6418)

### Testing

Ran smoke tests on mug.  We don't have any integration tests for SCSD.  I did hit various endpoints with GET and confirmed identical output with the version of SCSD previously running on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High Level Charts Changes

```diff
diff -r charts/v3.0/cray-hms-scsd/Chart.yaml charts/v3.1/cray-hms-scsd/Chart.yaml
3c3
< version: 3.0.2
---
> version: 3.1.0
15c15
< appVersion: "1.20.0"
---
> appVersion: "1.21.0"
diff -r charts/v3.0/cray-hms-scsd/values.yaml charts/v3.1/cray-hms-scsd/values.yaml
11,12c11,12
<   appVersion: 1.20.0
<   testVersion: 1.20.0
---
>   appVersion: 1.21.0
>   testVersion: 1.21.0
```