### PR TITLE
CASMHMS-6359: Added support for pprof builds

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-04-03
+
+### Added
+
+- Added support for pprof builds
+
 ## [3.1.0] - 2025-03-25
 
 ### Security

--- a/charts/v3.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v3.1/cray-hms-scsd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-scsd"
-version: 3.1.0
+version: 3.1.1
 description: "Kubernetes resources for cray-hms-scsd"
 home: "https://github.com/Cray-HPE/hms-scsd-charts"
 sources:
@@ -12,6 +12,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.21.0"
+appVersion: "1.22.0"
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-scsd-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-scsd-pprof:1.21.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v3.1/cray-hms-scsd/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "1.22.0"
 annotations:
   artifacthub.io/images: |-
     - name: cray-scsd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-scsd-pprof:1.21.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-scsd-pprof:1.22.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-scsd/values.yaml
+++ b/charts/v3.1/cray-hms-scsd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.21.0
-  testVersion: 1.21.0
+  appVersion: 1.22.0
+  testVersion: 1.22.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-scsd

--- a/cray-hms-scsd.compatibility.yaml
+++ b/cray-hms-scsd.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.19.0"
   "3.0.2": "1.20.0"
   "3.1.0": "1.21.0"
+  "3.1.1": "1.22.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Added pprof image support to SCSD.

Also completed a minor update of the go module dependencies.

Adopted app version 1.22.0 for CSM 1.7.0 (helm chart 3.1.1)

### Issues and Related PRs

* Resolves [CASMHMS-6359](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6359)

### Testing

Ran CT tests on mug with both the pprof and non-pprof images.  Also used pprof client from my laptop to comfirm pprof functionality on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable