### PR TITLE
CASMHMS-6398: Resolve some scaling and resource usage issues

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2025-05-28
+
+### Updated
+
+- Updated image and module dependencies
+- Explicitly closed all request and response bodies using hms-base functions
+- Fixed bug in three places where response bodies were not being closed
+- Internal tracking ticket: CASMHMS-6398
+
 ## [3.1.2] - 2025-05-14
 
 ### Updated

--- a/charts/v3.1/cray-hms-scsd/Chart.yaml
+++ b/charts/v3.1/cray-hms-scsd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-scsd"
-version: 3.1.2
+version: 3.1.3
 description: "Kubernetes resources for cray-hms-scsd"
 home: "https://github.com/Cray-HPE/hms-scsd-charts"
 sources:
@@ -12,9 +12,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.22.0"
+appVersion: "1.23.0"
 annotations:
   artifacthub.io/images: |-
     - name: cray-scsd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-scsd-pprof:1.22.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-scsd-pprof:1.23.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-scsd/values.yaml
+++ b/charts/v3.1/cray-hms-scsd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.22.0
-  testVersion: 1.22.0
+  appVersion: 1.23.0
+  testVersion: 1.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-scsd

--- a/cray-hms-scsd.compatibility.yaml
+++ b/cray-hms-scsd.compatibility.yaml
@@ -34,6 +34,7 @@ chartVersionToApplicationVersion:
   "3.1.0": "1.21.0"
   "3.1.1": "1.22.0"
   "3.1.2": "1.22.0"
+  "3.1.3": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Fixed a bug in three places where response bodies were not being closed

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Ignoring resource issues associated with TRS in this PR as the version used is very old and there is an HMS ticket open to update it to a more recent version.

Adopted app version 1.23.0 for CSM 1.7.0 (helm chart 3.1.3).

### Issues and Related PRs

* Resolves [CASMHMS-6398](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6398)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable